### PR TITLE
Updated the version to release the "async_await" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qutex"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 license = "MIT"
 description = """\


### PR DESCRIPTION
Hey :wave:!

I see that an `async_await` feature was added but no version containing it has been pushed to crates.io, so I just bumped the version number so that you can re-publish the crate :smile:.

Thank you! :heart: 